### PR TITLE
Add passlib

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -61,6 +61,6 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -32,7 +32,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into registry registry.redhat.io
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: registry.redhat.io

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -39,6 +39,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log into registry registry.redhat.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REDHAT_USER }}
+          password: ${{ secrets.REDHAT_TOKEN }}
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.redhat.io/openshift4/ose-cli:v4.8
 
 ENV TINI_VERSION=v0.19.0
 ENV KUBESEAL_VERSION=v0.16.0
 ENV KUSTOMIZE_VERSION=v4.2.0
-ENV OC_CLI_VERSON=4.7.0-0.okd-2021-08-22-163618
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
 ADD bin/entrypoint.sh /bin/entrypoint
@@ -21,10 +20,6 @@ RUN curl -Ls https://github.com/bitnami-labs/sealed-secrets/releases/download/${
 RUN curl -Ls https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | \
   tar -zx -C /bin && \
   chmod +x /bin/kustomize
-
-RUN curl -Ls https://github.com/openshift/okd/releases/download/${OC_CLI_VERSON}/openshift-client-linux-${OC_CLI_VERSON}.tar.gz | \
-  tar -zx -C /bin && \
-  chmod +x /bin/oc
 
 ENV HOME=/ansible
 RUN mkdir -p ${HOME} ${HOME}/.ansible/tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD bin/entrypoint.sh /bin/entrypoint
 
 RUN dnf install -y git hostname jq python38 python38-pip make && \
   pip3 install --upgrade pip && \
-  pip install openshift kubernetes jq pyyaml pyjwt jmespath ansible "molecule[lint]" && \
+  pip install openshift kubernetes jq pyyaml pyjwt jmespath ansible "molecule[lint]" passlib && \
   chmod +x /bin/tini /bin/entrypoint && \
   rm -rf /var/cache/dnf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.redhat.io/openshift4/ose-cli:v4.8
 
 ENV TINI_VERSION=v0.19.0
 ENV KUBESEAL_VERSION=v0.16.0
-ENV KUSTOMIZE_VERSION=v4.2.0
+ENV KUSTOMIZE_VERSION=v4.5.1
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
 ADD bin/entrypoint.sh /bin/entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/
 ADD bin/entrypoint.sh /bin/entrypoint
 
 RUN dnf install -y git hostname jq python38 python38-pip make && \
-  pip3 install --upgrade pip && \
-  pip install openshift kubernetes jq pyyaml pyjwt jmespath ansible "molecule[lint]" passlib && \
+  pip3.8 install --upgrade pip && \
+  pip3.8 install openshift kubernetes jq pyyaml pyjwt jmespath ansible "molecule[lint]" passlib && \
   chmod +x /bin/tini /bin/entrypoint && \
   rm -rf /var/cache/dnf
 


### PR DESCRIPTION
To be able to use the blowfish hash in Ansible, the passlib python module is required
https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#hashing-and-encrypting-strings-and-passwords

Instead of installing the cli into the image, just start with the cli image from Red Hat

Update Kustomize